### PR TITLE
Update format_course_data values

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -222,6 +222,8 @@ class CoursesApiDataLoader(AbstractDataLoader):
     def format_course_data(self, body):
         defaults = {
             'title': body['name'],
+            'short_description': body['short_description'],
+            'card_image_url': body['media']['image']['small'],
         }
 
         return defaults


### PR DESCRIPTION
This PR updates format_course_data method in order to map short_description and card_image_url comming from LMS Courses API response to the course creation/update in discovery service. 
Those values are requested by the Ecommerce Basket View to render the template.